### PR TITLE
Added custom render for tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,10 @@ module.exports = (api) => {
     plugins: [
       '@babel/plugin-transform-regenerator',
       '@babel/plugin-transform-runtime',
-      'babel-plugin-styled-components',
+      [
+        'babel-plugin-styled-components',
+        { ssr: false, displayName: false, namespace: 'sc' }, // See https://github.com/styled-components/jest-styled-components/issues/294#issuecomment-708947821
+      ],
       '@babel/plugin-proposal-optional-chaining',
     ],
     presets,

--- a/src/components/pages/AnotherPage/AnotherPage.spec.tsx
+++ b/src/components/pages/AnotherPage/AnotherPage.spec.tsx
@@ -1,11 +1,9 @@
-import { render, screen } from '@testing-library/react';
 import AnotherPage from './AnotherPage';
 import { LocalStoresRoot } from '../../../stores';
+import render from '../../../test-utils/render';
 
 test('renders', async () => {
-  const {
-    container: { firstChild },
-  } = render(
+  const { hasStyle, screen, takeSnapshot } = render(
     <LocalStoresRoot>
       <AnotherPage />
     </LocalStoresRoot>
@@ -15,6 +13,7 @@ test('renders', async () => {
   expect(screen.getByText("I'm another example page!")).toHaveStyle(
     `border-radius: 10px`
   );
-  expect(firstChild).toHaveStyle(`border-radius: 10px`);
-  expect(firstChild).toMatchSnapshot();
+
+  hasStyle('border-radius: 10px');
+  takeSnapshot();
 });

--- a/src/components/pages/AnotherPage/AnotherPage.tsx
+++ b/src/components/pages/AnotherPage/AnotherPage.tsx
@@ -10,7 +10,7 @@ const StyledComponentsExample = styled.div`
 const AnotherPage: FC = () => (
   <StyledComponentsExample>
     I&apos;m another example page!
-    <Button color={'blue'} />
+    <Button color="blue" />
   </StyledComponentsExample>
 );
 

--- a/src/components/pages/ExamplePage/ExamplePage.spec.tsx
+++ b/src/components/pages/ExamplePage/ExamplePage.spec.tsx
@@ -1,11 +1,9 @@
-import { render, screen } from '@testing-library/react';
 import ExamplePage from './ExamplePage';
 import { LocalStoresRoot } from '../../../stores';
+import render from '../../../test-utils/render';
 
 test('renders', async () => {
-  const {
-    container: { firstChild },
-  } = render(
+  const { screen, hasStyle, takeSnapshot } = render(
     <LocalStoresRoot>
       <ExamplePage />
     </LocalStoresRoot>
@@ -15,6 +13,7 @@ test('renders', async () => {
   expect(screen.getByText("I'm an example page!")).toHaveStyle(
     `border-radius: 10px`
   );
-  expect(firstChild).toHaveStyle(`border-radius: 10px`);
-  expect(firstChild).toMatchSnapshot();
+
+  takeSnapshot();
+  hasStyle(`border-radius: 10px`);
 });

--- a/src/test-utils/render.ts
+++ b/src/test-utils/render.ts
@@ -7,7 +7,10 @@ import 'jest-styled-components';
 interface RenderResult extends ReturnType<typeof testingReactRender> {
   component: ChildNode | null;
   screen: typeof testingReactScreen;
-  hasStyle: (style: string | Record<string, string | undefined>) => void;
+  hasStyle: (
+    style: string | Record<string, string | undefined>,
+    options?: { media?: string; modifier?: string }
+  ) => void;
   takeSnapshot: () => void;
 }
 
@@ -19,7 +22,10 @@ const render = (ui: React.ReactElement): RenderResult => {
     ...result,
     component,
     screen: testingReactScreen,
-    hasStyle: (style: string | Record<string, string | undefined>): void => {
+    hasStyle: (
+      style: string | Record<string, string | undefined>,
+      options?: { media?: string; modifier?: string }
+    ): void => {
       if (typeof style === 'object') {
         Object.keys(style).forEach((styleKey) => {
           expect(component).toHaveStyleRule(styleKey, style[styleKey]);
@@ -30,7 +36,7 @@ const render = (ui: React.ReactElement): RenderResult => {
           .join('')
           .split(':')
           .map((s) => s.trim());
-        expect(component).toHaveStyleRule(key, value);
+        expect(component).toHaveStyleRule(key, value, options);
       }
     },
     takeSnapshot: (): void => {

--- a/src/test-utils/render.ts
+++ b/src/test-utils/render.ts
@@ -1,0 +1,42 @@
+import {
+  render as testingReactRender,
+  screen as testingReactScreen,
+} from '@testing-library/react';
+import 'jest-styled-components';
+
+interface RenderResult extends ReturnType<typeof testingReactRender> {
+  component: ChildNode | null;
+  screen: typeof testingReactScreen;
+  hasStyle: (style: string | Record<string, string | undefined>) => void;
+  takeSnapshot: () => void;
+}
+
+const render = (ui: React.ReactElement): RenderResult => {
+  const result = testingReactRender(ui);
+  const component = result.container.firstChild;
+
+  return {
+    ...result,
+    component,
+    screen: testingReactScreen,
+    hasStyle: (style: string | Record<string, string | undefined>): void => {
+      if (typeof style === 'object') {
+        Object.keys(style).forEach((styleKey) => {
+          expect(component).toHaveStyleRule(styleKey, style[styleKey]);
+        });
+      } else if (typeof style === 'string') {
+        const [key, value] = style
+          .split(';')
+          .join('')
+          .split(':')
+          .map((s) => s.trim());
+        expect(component).toHaveStyleRule(key, value);
+      }
+    },
+    takeSnapshot: (): void => {
+      expect(component).toMatchSnapshot();
+    },
+  };
+};
+
+export default render;


### PR DESCRIPTION
Added a custom wrapper around `@testing-library/react`'s `render` function for quick snapshots and style checking.